### PR TITLE
Removed/commented assert code on S3 store to have an option to use AWS.ECSCredentials

### DIFF
--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -55,9 +55,9 @@ class S3Store extends DataStore {
 
         this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
 
-        assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set');
-        assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set');
-        assert.ok(options.bucket, '[S3Store] `bucket` must be set');
+        // assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set');
+        // assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set');
+        // assert.ok(options.bucket, '[S3Store] `bucket` must be set');
 
         this.tmp_dir_prefix = options.tmpDirPrefix || 'tus-s3-store';
         this.bucket_name = options.bucket;


### PR DESCRIPTION
Removed/commented assert code on S3 store to have an option to use AWS.ECSCredentials